### PR TITLE
Updated the Stamen map tiles urls in the Examples to the CDN url 

### DIFF
--- a/examples/Layers.tsx
+++ b/examples/Layers.tsx
@@ -46,7 +46,7 @@ export default function Layers(): JSX.Element {
                 />
                 <RLayerTile
                     properties={{label: 'Watercolor'}}
-                    url='http://c.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg'
+                    url='https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
                 />
                 <RLayerTileJSON
                     properties={{label: 'Mapbox TileJSON'}}

--- a/examples/VectorTiles.tsx
+++ b/examples/VectorTiles.tsx
@@ -84,7 +84,7 @@ export default function VectorTiles(): JSX.Element {
                 {/* This is the background raster map */}
                 <RLayerTile
                     properties={{label: 'Watercolor'}}
-                    url='http://c.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg'
+                    url='https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
                 />
                 {/* These are the administrative borders */}
                 <RLayerVectorTile


### PR DESCRIPTION
The current URL version is not behind https. Chrome does automatic upgrades of `http` to `https`, which breaks the example. Just check the the [example](https://mmomtchev.github.io/rlayers/#/vectortiles) in Chrome.

After [talking with Stamen team](https://twitter.com/mappingmashups/status/1486469541118955523) I discovered they have a CDN url. After looking for that URL in the OpenLayers codebase I found it was already use somewhere.

So I just upgraded the examples here.