### PR TITLE
Publish rlayers as ES6 modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.4.0] WIP
+ * Provide an alternative ES6 modules version of rlayers with a `package.json` exports map
  * Render the examples in React 18 mode when available
 
 ### [1.3.4] 2022-04-26

--- a/package.json
+++ b/package.json
@@ -4,11 +4,36 @@
   "description": "React Components for OpenLayers",
   "main": "index.js",
   "types": "index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./dist/index.js"
+    },
+    "./style": {
+      "require": "./style/index.js",
+      "import": "./dist/style/index.js"
+    },
+    "./layer": {
+      "require": "./layer/index.js",
+      "import": "./dist/layer/index.js"
+    },
+    "./control": {
+      "require": "./control/index.js",
+      "import": "./dist/control/index.js"
+    },
+    "./interaction": {
+      "require": "./interaction/index.js",
+      "import": "./dist/interaction/index.js"
+    }
+  },
   "scripts": {
-    "clean": "tsc --build --clean && rimraf docs control style layer interaction",
-    "build": "npm run clean && npm run build:lib && npm run build:examples && npm run build:doc",
+    "clean": "tsc --build --clean && rimraf docs control style layer interaction dist",
+    "build": "npm run clean && npm run build:lib && npm run build:lib:es6 && npm run build:examples && npm run build:doc",
     "build:lib": "tsc && npm run build:css",
+    "build:lib:es6": "tsc -p tsconfig.es6.json && npm run build:css:es6",
     "build:css": "copyfiles -f src/control/layers.css control",
+    "build:css:es6": "copyfiles -f src/control/layers.css dist/control",
     "build:examples": "webpack --mode=production --env production",
     "build:doc": "npx styleguidist build",
     "dev": "webpack-cli serve --mode=development --env development --open",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,38 @@
+{
+    "compilerOptions": {
+        "sourceMap": true,
+        "noImplicitAny": false,
+        "lib": [
+            "esnext",
+            "dom",
+            "dom.iterable"
+        ],
+        "declaration": true,
+        "declarationMap": true,
+        "removeComments": true,
+        "allowSyntheticDefaultImports": true,
+        "jsx": "react",
+        "allowJs": true,
+        "baseUrl": "./",
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "moduleResolution": "node",
+        "downlevelIteration": true,
+        "skipLibCheck": true,
+        "paths": {
+            "rlayers": [
+                "./src"
+            ],
+            "rlayers/*": [
+                "./src/*"
+            ]
+        }
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [],
+    "ts-node": {
+        "transpileOnly": true
+    }
+}

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -2,14 +2,14 @@
     "compilerOptions": {
         "sourceMap": true,
         "noImplicitAny": false,
-        "module": "commonjs",
-        "target": "es5",
+        "module": "esnext",
+        "target": "es6",
         "lib": [
             "esnext",
             "dom",
             "dom.iterable"
         ],
-        "outDir": ".",
+        "outDir": "./dist",
         "declaration": true,
         "declarationMap": true,
         "removeComments": true,

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -1,41 +1,11 @@
 {
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "sourceMap": true,
-        "noImplicitAny": false,
         "module": "esnext",
         "target": "es6",
-        "lib": [
-            "esnext",
-            "dom",
-            "dom.iterable"
-        ],
         "outDir": "./dist",
-        "declaration": true,
-        "declarationMap": true,
-        "removeComments": true,
-        "allowSyntheticDefaultImports": true,
-        "jsx": "react",
-        "allowJs": true,
-        "baseUrl": "./",
-        "esModuleInterop": true,
-        "resolveJsonModule": true,
-        "moduleResolution": "node",
-        "downlevelIteration": true,
-        "skipLibCheck": true,
-        "paths": {
-            "rlayers": [
-                "./src"
-            ],
-            "rlayers/*": [
-                "./src/*"
-            ]
-        }
     },
     "include": [
         "./src"
-    ],
-    "exclude": [],
-    "ts-node": {
-        "transpileOnly": true
-    }
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,40 +1,13 @@
 {
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "sourceMap": true,
-        "noImplicitAny": false,
         "module": "commonjs",
         "target": "es5",
-        "lib": [
-            "esnext",
-            "dom",
-            "dom.iterable"
-        ],
-        "outDir": ".",
-        "declaration": true,
-        "declarationMap": true,
-        "removeComments": true,
-        "allowSyntheticDefaultImports": true,
-        "jsx": "react",
-        "allowJs": true,
-        "baseUrl": "./",
-        "esModuleInterop": true,
-        "resolveJsonModule": true,
-        "moduleResolution": "node",
-        "downlevelIteration": true,
-        "skipLibCheck": true,
-        "paths": {
-            "rlayers": [
-                "./src"
-            ],
-            "rlayers/*": [
-                "./src/*"
-            ]
-        }
+        "outDir": "."
     },
     "include": [
         "./src"
     ],
-    "exclude": [],
     "ts-node": {
         "transpileOnly": true
     }


### PR DESCRIPTION
Provide an alternative import point via `package.json` exports map for importing as ES6 modules