### PR TITLE
Expose interpolate option for Raster Image Tile Layers

### DIFF
--- a/src/layer/RLayerTile.tsx
+++ b/src/layer/RLayerTile.tsx
@@ -21,6 +21,11 @@ export interface RLayerTileProps extends RLayerRasterProps {
      * (ie pass a constant variable, not an anonymous {})
      */
     tileGrid?: TileGrid;
+    /**
+     * By default, OpenLayers uses interpolation to smooth images when zooming.
+     * Setting this value to true will override that.
+     */
+    noIterpolation?: boolean;
 }
 
 /**
@@ -42,6 +47,7 @@ export default class RLayerTile extends RLayerRaster<RLayerTileProps> {
     createSource(): void {
         this.source = new XYZ({
             url: this.props.url,
+            interpolate: !this.props.noIterpolation,
             projection: this.props.projection,
             tileGrid: this.props.tileGrid
         });

--- a/src/layer/RLayerTileWebGL.tsx
+++ b/src/layer/RLayerTileWebGL.tsx
@@ -21,6 +21,11 @@ export interface RLayerTileWebGLProps extends RLayerWebGLProps {
      * (ie pass a constant variable, not an anonymous {})
      */
     tileGrid?: TileGrid;
+    /**
+     * By default, OpenLayers uses interpolation to smooth images when zooming.
+     * Setting this value to true will override that.
+     */
+    noIterpolation?: boolean;
 }
 
 /**
@@ -46,7 +51,7 @@ export default class RLayerTileWebGL extends RLayerWebGL<RLayerTileWebGLProps> {
     createSource(): void {
         this.source = new XYZ({
             url: this.props.url,
-            interpolate: true,
+            interpolate: !this.props.noIterpolation,
             projection: this.props.projection,
             tileGrid: this.props.tileGrid,
             crossOrigin: 'anonymous'


### PR DESCRIPTION
Just a small usecase I had. Not passing `noInterpolation` will keep the default behaviour as before (OL defaults to true).