### PR TITLE
Changed type def for projection to allow custom projection instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Provide a CDN bundle version for direct inclusion in static pages
  * Render the examples in React 18 mode when available
  * New documentation subsystem based on `documentation.js` with `documentation-stylist`
+ * Always use `ProjectionLike` type for projections [#62]
 
 ### [1.3.4] 2022-04-26
  * TypeScript compatibility with `@types/react@18.0.0`

--- a/src/RGeolocation.tsx
+++ b/src/RGeolocation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {MapBrowserEvent} from 'ol';
+import {ProjectionLike} from 'ol/proj';
 import Geolocation from 'ol/Geolocation';
 import BaseEvent from 'ol/events/Event';
 
@@ -21,7 +21,7 @@ export interface RGeolocationProps {
     };
     /** Projection for the returned coordinates
      * @default viewProjection */
-    projection?: string;
+    projection?: ProjectionLike;
     /** Called on every change */
     onChange?: (this: RGeolocation, e: BaseEvent) => void;
     /** Called on error */

--- a/src/RMap.tsx
+++ b/src/RMap.tsx
@@ -3,8 +3,8 @@ import {Map, View, MapBrowserEvent, MapEvent} from 'ol';
 import RenderEvent from 'ol/render/Event';
 import BaseEvent from 'ol/events/Event';
 import {Extent} from 'ol/extent';
-
 import {Coordinate} from 'ol/coordinate';
+import {ProjectionLike} from 'ol/proj';
 
 import {RContext} from './context';
 import {RlayersBase} from './REvent';
@@ -42,7 +42,7 @@ export interface RMapProps extends PropsWithChildren<unknown> {
     /** View projection
      * @default 'ESPG:3857'
      */
-    projection?: string;
+    projection?: ProjectionLike;
     /** Called immediately on click */
     onClick?: (this: RMap, e: MapBrowserEvent<UIEvent>) => boolean | void;
     /** Called on single click when the double click timer has expired */

--- a/src/layer/RLayer.tsx
+++ b/src/layer/RLayer.tsx
@@ -3,6 +3,7 @@ import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
 import LayerRenderer from 'ol/renderer/Layer';
 import BaseEvent from 'ol/events/Event';
+import {ProjectionLike} from 'ol/proj';
 
 import {RContext, RContextType} from '../context';
 import {RlayersBase} from '../REvent';
@@ -31,7 +32,7 @@ export interface RLayerProps extends PropsWithChildren<unknown> {
     /** A set of properties that can be accessed later by .get()/.getProperties() */
     properties?: Record<string, unknown>;
     /** The layer will be reprojected if its projection is different than the map */
-    projection?: string;
+    projection?: ProjectionLike;
     /** Called on every change */
     onChange?: (this: RLayer<RLayerProps>, e: BaseEvent) => void;
 }


### PR DESCRIPTION
Last PR! I had a need for a custom projection and this would be nicer than casting `projection as unknown as string`.