### PR TITLE
Unset layer properties on transition to `undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [1.4.9]
 
 -   Allow using projections other than Web Mercator with `RVectorTile` (the vector tile projection must still match the view projection)
+-   Fix [#133], certain layer properties do not update if they transition from a defined value to `undefined`
 
 ### [1.4.8] 2023-01-08
 

--- a/src/layer/RLayer.tsx
+++ b/src/layer/RLayer.tsx
@@ -61,11 +61,8 @@ export default class RLayer<P extends RLayerProps> extends RlayersBase<P, Record
             'minZoom',
             'maxZoom'
         ]) {
-            if (this.props[p] !== undefined) {
-                const m = p.charAt(0).toUpperCase() + p.substring(1);
-                if (this.props[p] !== (prevProps && prevProps[p]))
-                    this.ol['set' + m](this.props[p]);
-            }
+            const m = p.charAt(0).toUpperCase() + p.substring(1);
+            if (this.props[p] !== (prevProps && prevProps[p])) this.ol['set' + m](this.props[p]);
         }
         if (this.source && this.props.attributions)
             this.source.setAttributions(this.props.attributions);

--- a/test/RVectorTiles.test.tsx
+++ b/test/RVectorTiles.test.tsx
@@ -160,6 +160,33 @@ describe('<RLayerVectorTiles>', () => {
         expect(layer.current?.source.getProjection()?.getCode()).toBe('EPSG:4326');
         unmount();
     });
+    it('should support maxResolution / minResolution', async () => {
+        const layer = React.createRef() as React.RefObject<RLayerVectorTile>;
+        const comp = (
+            <RMap {...common.mapProps}>
+                <RLayerVectorTile
+                    projection='EPSG:4326'
+                    ref={layer}
+                    {...props}
+                    maxResolution={1000}
+                    minResolution={100}
+                />
+            </RMap>
+        );
+        const {unmount, rerender} = render(comp);
+        expect(layer.current?.ol.getMaxResolution()).toBe(1000);
+        expect(layer.current?.ol.getMinResolution()).toBe(100);
+
+        rerender(
+            <RMap {...common.mapProps}>
+                <RLayerVectorTile projection='EPSG:4326' ref={layer} {...props} />
+            </RMap>
+        );
+        expect(layer.current?.ol.getMaxResolution()).toBeUndefined();
+        expect(layer.current?.ol.getMinResolution()).toBeUndefined();
+
+        unmount();
+    });
     it('should update the style', async () => {
         const ref = React.createRef() as React.RefObject<RLayerVectorTile>;
         const comp = (style) => (


### PR DESCRIPTION
Fixes #133 