### PR TITLE
Export RBaseStyle with its props

### DIFF
--- a/src/style/index.ts
+++ b/src/style/index.ts
@@ -1,3 +1,4 @@
+export {default as RBaseStyle, RBaseStyleProps} from './RBaseStyle';
 export {default as RStyle, RStyleRef, RStyleLike, useRStyle, createRStyle} from './RStyle';
 export {default as RStyleArray} from './RStyleArray';
 export {default as RStroke} from './RStroke';


### PR DESCRIPTION
It's needed to create new styles

_Example of usage:_

```
import FillPattern from "ol-ext/style/FillPattern";
import { ColorLike } from "ol/colorlike";
import { Fill, Image } from "ol/style";
import { RBaseStyle, RBaseStyleProps } from "rlayers/style";

/**
 * @propsfor RFillPattern
 */
export interface RFillPatternProps extends RBaseStyleProps {
  /** image */
  image?: Image;
  /** opacity */
  opacity?: number;
  /** pattern */
  pattern: "dot" | "circle" | "tile" | "square" | "cross" | "hatch";
  /** color */
  color: ColorLike;
  /** fill */
  fillColor?: ColorLike;
  /** offset */
  offset?: number;
  /** size */
  size: number;
  /** spacing */
  spacing: number;
  /** angle */
  angle: number;
  /** scale */
  scale?: number;
}

/**
 * A component for adding a fill pattern to a style
 *
 * Requires an `RStyle` context
 */
export default class RFillPattern extends RBaseStyle<RFillPatternProps> {
  static classProps = [
    "image",
    "opacity",
    "pattern",
    "color",
    "fillColor",
    "offset",
    "size",
    "spacing",
    "angle",
    "scale",
  ];
  declare ol: FillPattern;

  create(props: RFillPatternProps): FillPattern {
    this.classProps = RFillPattern.classProps;
    return new FillPattern({
      ...props,
      fill: props.fillColor ? new Fill({ color: props.fillColor }) : undefined,
    });
  }

  set(ol: FillPattern): void {
    if (this.context.style?.setFill) return this.context.style.setFill(ol);
    /* istanbul ignore next */
    throw new Error("Parent element does not support a fill");
  }
}

```

_Example of output:_

<img width="948" alt="image" src="https://user-images.githubusercontent.com/856260/223276269-eb5f01c9-0acf-4795-bf41-60a5c0f2a4a5.png">
