### PR TITLE
Add FeatureUrlLoader and LoadingStrategy to RLayerBaseVectorProps

### DIFF
--- a/src/layer/RLayerBaseVector.tsx
+++ b/src/layer/RLayerBaseVector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Feature, MapBrowserEvent} from 'ol';
-import {VectorSourceEvent} from 'ol/source/Vector';
+import {LoadingStrategy, VectorSourceEvent} from 'ol/source/Vector';
 import RenderEvent from 'ol/render/Event';
 import BaseVector from 'ol/layer/BaseVector';
 import CanvasVectorLayerRenderer from 'ol/renderer/canvas/VectorLayer';
@@ -9,7 +9,7 @@ import CanvasVectorImageLayerRenderer from 'ol/renderer/canvas/VectorImageLayer'
 import WebGLPointsLayerRenderer from 'ol/renderer/webgl/PointsLayer';
 import {Vector as SourceVector} from 'ol/source';
 import FeatureFormat from 'ol/format/Feature';
-import {FeatureLoader} from 'ol/featureloader';
+import {FeatureLoader, FeatureUrlFunction} from 'ol/featureloader';
 import Geometry from 'ol/geom/Geometry';
 import BaseObject from 'ol/Object';
 
@@ -23,8 +23,8 @@ import debug from '../debug';
  * @propsfor RLayerBaseVector
  */
 export interface RLayerBaseVectorProps extends RLayerProps {
-    /** URL for loading features, requires `format` */
-    url?: string;
+    /** URL for loading features can be a function of type `FeatureUrlFunction`, requires `format` */
+    url?: string | FeatureUrlFunction;
     /**
      * Width of the frame around the viewport that shall be rendered too
      * so that the symbols, whose center is outside of the viewport,
@@ -47,6 +47,8 @@ export interface RLayerBaseVectorProps extends RLayerProps {
     loader?: FeatureLoader;
     /** OpenLayers default style for features without `style` */
     style?: RStyleLike;
+    /**  OpenLayers option to specify LoadingStrategy default is `all` strategy */
+    strategy?: LoadingStrategy;
     /**
      * Wrap features around the antimeridian. Cannot be dynamically updated once the layer is created.
      * @default false

--- a/src/layer/RLayerCluster.tsx
+++ b/src/layer/RLayerCluster.tsx
@@ -36,7 +36,8 @@ export default class RLayerCluster extends RLayerBaseVector<RLayerClusterProps> 
             url: this.props.url,
             format: this.props.format,
             loader: this.props.loader,
-            wrapX: this.props.wrapX
+            wrapX: this.props.wrapX,
+            strategy: this.props.strategy
         });
         this.source = new SourceCluster({source: this.cluster, distance: this.props.distance});
         this.ol = new LayerVector({

--- a/src/layer/RLayerHeatmap.tsx
+++ b/src/layer/RLayerHeatmap.tsx
@@ -43,7 +43,8 @@ export default class RLayerHeatmap extends RLayerBaseVector<RLayerHeatmapProps> 
             url: this.props.url,
             format: this.props.format,
             loader: this.props.loader,
-            wrapX: this.props.wrapX
+            wrapX: this.props.wrapX,
+            strategy: this.props.strategy
         });
         this.ol = new LayerHeatmap({...props, source: this.source});
         return [this.ol, this.source];

--- a/src/layer/RLayerVector.tsx
+++ b/src/layer/RLayerVector.tsx
@@ -29,7 +29,8 @@ export default class RLayerVector extends RLayerBaseVector<RLayerBaseVectorProps
             url: this.props.url,
             format: this.props.format,
             loader: this.props.loader,
-            wrapX: this.props.wrapX
+            wrapX: this.props.wrapX,
+            strategy: this.props.strategy
         });
         this.ol = new LayerVector({
             ...props,

--- a/src/layer/RLayerVectorImage.tsx
+++ b/src/layer/RLayerVectorImage.tsx
@@ -29,7 +29,8 @@ export default class RLayerVectorImage extends RLayerBaseVector<RLayerBaseVector
             url: this.props.url,
             format: this.props.format,
             loader: this.props.loader,
-            wrapX: this.props.wrapX
+            wrapX: this.props.wrapX,
+            strategy: this.props.strategy
         });
         this.ol = new LayerVectorImage({
             ...props,


### PR DESCRIPTION
This requirement came to light when trying to implement [this](https://openlayers.org/en/latest/examples/vector-wfs.html) example with the use of RLayers. I found out that no `FeatureUrlFunction` could be passed as an `url` to `RLayerVector` even though the underlying `Vector` of OpenLayers has full support for it.

In addition to this, support for `strategy` is added in the same way. Again OpenLayers `Vector` has full support for it. By omitting this value the default (`all`) is used, returning an `extent` of `[-Infinity, -Infinity, Infinity, Infinity]`. Loading all features of a large dataset is not always preferred, by allowing this to be passed in the alternative loading strategy `bbox` can also be used, returning only the visible extent.