### PR TITLE
support for tileSize property in TileJSON source

### DIFF
--- a/src/layer/RLayerTileJSON.tsx
+++ b/src/layer/RLayerTileJSON.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Map} from 'ol';
 import {Tile as LayerTile} from 'ol/layer';
 import {TileJSON} from 'ol/source';
+import type {Options} from 'ol/source/TileJSON';
 import TileGrid from 'ol/tilegrid/TileGrid';
 
 import {RContextType} from '../context';
@@ -14,6 +15,8 @@ export interface RLayerTileJSONProps extends RLayerRasterProps {
     /** An URL for loading the tiles with the usual {x}{y}{z} semantics */
     url?: string;
     projection?: never;
+    // other, less frequently used options
+    tileSize?: Options['tileSize'];
 }
 
 /**
@@ -28,7 +31,8 @@ export default class RLayerTileJSON extends RLayerRaster<RLayerTileJSONProps> {
     constructor(props: Readonly<RLayerTileJSONProps>, context?: React.Context<RContextType>) {
         super(props, context);
         this.source = new TileJSON({
-            url: this.props.url
+            url: this.props.url,
+            tileSize: this.props.tileSize
         });
         this.ol = new LayerTile({source: this.source});
         this.eventSources = [this.ol, this.source];


### PR DESCRIPTION
Fixes #173 and adds support for the `tileSize` property in `TileJSON`

`tileSize` is a property of `TileJSON` that rarely needs to be set. [MapTiler](https://www.maptiler.com/) seems to require this property though, without it labels (e.g. street and city names) are not displayed correctly.

@mmomtchev: Should we support the other properties as well? (`cacheSize`, `crossOrigin` etc)  I can add them quickly if you want.