### PR TITLE
more options for vector tile sources

### DIFF
--- a/src/layer/RLayer.tsx
+++ b/src/layer/RLayer.tsx
@@ -29,6 +29,10 @@ export interface RLayerProps extends PropsWithChildren<unknown> {
     maxZoom?: number;
     /** Custom attributions string */
     attributions?: string;
+    /** Initial tile cache size */
+    cacheSize?: number | undefined;
+    /** Wrap features around the antimeridian */
+    wrapX?: boolean | undefined;
     /** A set of properties that can be accessed later by .get()/.getProperties() */
     properties?: Record<string, unknown>;
     /** The layer will be reprojected if its projection is different than the map */

--- a/src/layer/RLayerVectorTile.tsx
+++ b/src/layer/RLayerVectorTile.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {VectorTile as LayerVectorTile} from 'ol/layer';
 import {VectorTile as SourceVectorTile} from 'ol/source';
+import type {Options} from 'ol/source/VectorTile';
 import FeatureFormat from 'ol/format/Feature';
 
 import {RContext, RContextType} from '../context';
@@ -33,6 +34,17 @@ export interface RLayerVectorTileProps extends RLayerProps {
      * this property currently does not support dynamic updates
      */
     renderBuffer?: number;
+    /* vector tile specific source options */
+    extent?: Options['extent'];
+    overlaps?: Options['overlaps'];
+    state?: Options['state'];
+    tileClass?: Options['tileClass'];
+    tileSize?: Options['tileSize'];
+    tileGrid?: Options['tileGrid'];
+    tileLoadFunction?: Options['tileLoadFunction'];
+    tileUrlFunction?: Options['tileUrlFunction'];
+    transition?: Options['transition'];
+    zDirection?: Options['zDirection'];
     /** onClick handler for loaded features */
     onClick?: (this: RLayerVectorTile, e: RFeatureUIEvent) => boolean | void;
     /** onPointerMove handler for loaded features */
@@ -64,7 +76,19 @@ export default class RLayerVectorTile extends RLayer<RLayerVectorTileProps> {
         this.source = new SourceVectorTile({
             url: this.props.url,
             format: this.props.format,
-            projection: this.props.projection
+            projection: this.props.projection,
+            cacheSize: this.props.cacheSize,
+            extent: this.props.extent,
+            overlaps: this.props.overlaps,
+            state: this.props.state,
+            tileClass: this.props.tileClass,
+            tileSize: this.props.tileSize,
+            tileGrid: this.props.tileGrid,
+            tileLoadFunction: this.props.tileLoadFunction,
+            tileUrlFunction: this.props.tileUrlFunction,
+            transition: this.props.transition,
+            wrapX: this.props.wrapX,
+            zDirection: this.props.zDirection
         });
         this.ol = new LayerVectorTile({
             style: RStyle.getStyle(this.props.style),


### PR DESCRIPTION
Sorry for the issue-less PR.

This PR extends the `RLayers` support for options supported by the OL [SourceVectorTile](https://github.com/openlayers/openlayers/blob/main/src/ol/source/VectorTile.js#L106) constructor. I.e. you can now specify a lot more options when using `RLayerVectorTile`.

My original motivation was that OL vector tile layers don't really support _overzooming_. 

E.g. if a vector tile source only supports tiles up to zoom level 15 the only way to allow zooming past that level is to provide a custom loader function. There's also an [OL example](https://openlayers.org/en/latest/examples/mapbox-vector-tiles-advanced.html) which is referenced in a lot of the overzooming Github issues.

Passing this loader function to the OL tile source is not possible at the moment.

I also added the other options supported by the source, e.g. `tileGrid`, `tileSize` etc.

Open points up for debate:

- I moved some of the options directly to the base props in `RLayerProps` (`wrapX`, `cacheSize`), they seem to be supported by most sources. We had this discussion before :-) If you're ok with it I can propagate the more common options to the supported sources.

- I saw there's an intermediate interface `RLayerBaseVectorProps` which supports some of the missing options. But extending this interface instead of `RLayerProps` gives a few errors which I didn't dare to fix. I can give it a shot if you'd rather have the vector specific props there.