### PR TITLE
Fix the Cluster, Heatmap and PinDrop examples

### DIFF
--- a/examples/Cluster.tsx
+++ b/examples/Cluster.tsx
@@ -35,7 +35,7 @@ export default function Cluster(): JSX.Element {
     return (
         <React.Fragment>
             <RMap className='example-map' initial={{center: fromLonLat([0, 0]), zoom: 1}}>
-                <RLayerStadia layer='toner' />
+                <RLayerStadia layer='stamen_toner' />
                 <RLayerCluster
                     ref={earthquakeLayer}
                     distance={distance}

--- a/examples/Heatmap.tsx
+++ b/examples/Heatmap.tsx
@@ -20,7 +20,7 @@ export default function Heatmap(): JSX.Element {
     return (
         <React.Fragment>
             <RMap className='example-map' initial={{center: fromLonLat([0, 0]), zoom: 1}}>
-                <RLayerStadia layer='toner' />
+                <RLayerStadia layer='stamen_toner' />
                 <RLayerHeatmap
                     blur={blur}
                     radius={radius}

--- a/examples/PinDrop.tsx
+++ b/examples/PinDrop.tsx
@@ -31,7 +31,7 @@ export default function PinDrop(): JSX.Element {
                             const coords = e.map.getCoordinateFromPixel(e.pixel);
                             e.target.setGeometry(new Point(coords));
                             // this stops OpenLayers from interpreting the event to pan the map
-                            e.preventDefault();
+                            e.disablePropagation();
                             return false;
                         }, [])}
                         onPointerDragEnd={useCallback((e) => {


### PR DESCRIPTION
- The Cluster and Heatmap examples hadn't their layer sources updated (needed `stamen_` prefix).
- In the PinDrop example, `e.preventDefault();` doesn't prevent the map being dragged, but `disablePropagation` does.