### PR TITLE
Adds tabIndex as a prop and passes it to the map div

### DIFF
--- a/src/RMap.tsx
+++ b/src/RMap.tsx
@@ -98,6 +98,8 @@ export interface RMapProps extends PropsWithChildren<unknown> {
     minZoom?: number;
     /** Maximum zoom level */
     maxZoom?: number;
+    /** Sets the tabIndex of the map, if set the map will need to be focused for mouse zoom to work  */
+    tabIndex?: number;
     /**
      * Allow rotation of the map.
      * Cannot be updated once the map is created.
@@ -188,6 +190,7 @@ export default class RMap extends RlayersBase<RMapProps, Record<string, never>> 
                 className={this.props.className}
                 style={{width: this.props.width, height: this.props.height}}
                 ref={this.target}
+                tabIndex={this.props.tabIndex}
             >
                 <RContext.Provider value={{map: this.ol, rMap: this}}>
                     {this.props.children}


### PR DESCRIPTION
Adds a tabIndex prop to the RMap component. This is then set on the main map div. If set it changes the default behaviour of the mouse wheel