### PR TITLE
Add className prop to all layers

### DIFF
--- a/examples/GeoTIFF.tsx
+++ b/examples/GeoTIFF.tsx
@@ -37,7 +37,7 @@ class RLayerGeoTIFF extends RLayer<RLayerGeoTIFFProps> {
     constructor(props: Readonly<RLayerGeoTIFFProps>, context?: React.Context<RContextType>) {
         super(props, context);
         this.createSource();
-        this.ol = new LayerTile({source: this.source});
+        this.ol = new LayerTile({source: this.source, className: props.className});
         this.eventSources = [this.ol, this.source];
     }
 

--- a/src/layer/RLayer.tsx
+++ b/src/layer/RLayer.tsx
@@ -13,6 +13,8 @@ import debug from '../debug';
  * @propsfor RLayerProps
  */
 export interface RLayerProps extends PropsWithChildren<unknown> {
+    /** A CSS class name to set to the layer element */
+    className?: string;
     /** State of the layer */
     visible?: boolean;
     /** Opacity when blending */

--- a/src/layer/RLayerImage.tsx
+++ b/src/layer/RLayerImage.tsx
@@ -35,7 +35,7 @@ export default class RLayerImage extends RLayer<RLayerImageProps> {
     constructor(props: Readonly<RLayerImageProps>, context?: React.Context<RContextType>) {
         super(props, context);
         this.createSource();
-        this.ol = new LayerImage({source: this.source});
+        this.ol = new LayerImage({source: this.source, className: props.className});
         this.eventSources = [this.ol, this.source];
     }
 

--- a/src/layer/RLayerRasterMBTiles.tsx
+++ b/src/layer/RLayerRasterMBTiles.tsx
@@ -65,7 +65,7 @@ export default class RLayerRasterMBTiles extends RLayerRaster<RLayerRasterMBTile
     constructor(props: Readonly<RLayerRasterMBTilesProps>, context?: React.Context<RContextType>) {
         super(props, context);
         this.addon = import('ol-mbtiles');
-        this.ol = new LayerTile();
+        this.ol = new LayerTile({className: props.className});
         this.source = null;
         this.abort = null;
         this.createSource();

--- a/src/layer/RLayerStadia.tsx
+++ b/src/layer/RLayerStadia.tsx
@@ -40,7 +40,7 @@ export default class RLayerStadia extends RLayerRaster<RLayerStadiaProps> {
             apiKey: this.props.apiKey,
             retina: this.props.retina ?? false
         });
-        this.ol = new LayerTile({source: this.source});
+        this.ol = new LayerTile({source: this.source, className: this.props.className});
         this.eventSources = [this.ol, this.source];
     }
 }

--- a/src/layer/RLayerTile.tsx
+++ b/src/layer/RLayerTile.tsx
@@ -46,7 +46,7 @@ export default class RLayerTile extends RLayerRaster<RLayerTileProps> {
     constructor(props: Readonly<RLayerTileProps>, context?: React.Context<RContextType>) {
         super(props, context);
         this.createSource();
-        this.ol = new LayerTile({source: this.source});
+        this.ol = new LayerTile({source: this.source, className: props.className});
         this.eventSources = [this.ol, this.source];
     }
 

--- a/src/layer/RLayerTileJSON.tsx
+++ b/src/layer/RLayerTileJSON.tsx
@@ -34,7 +34,7 @@ export default class RLayerTileJSON extends RLayerRaster<RLayerTileJSONProps> {
             url: this.props.url,
             tileSize: this.props.tileSize
         });
-        this.ol = new LayerTile({source: this.source});
+        this.ol = new LayerTile({source: this.source, className: this.props.className});
         this.eventSources = [this.ol, this.source];
     }
 

--- a/src/layer/RLayerTileWebGL.tsx
+++ b/src/layer/RLayerTileWebGL.tsx
@@ -44,7 +44,8 @@ export default class RLayerTileWebGL extends RLayerWebGL<RLayerTileWebGLProps, I
         this.ol = new LayerTileWebGL({
             opacity: 0.9,
             source: this.source as unknown as SourceDataTile<DataTile>,
-            cacheSize: props.cacheSize
+            cacheSize: props.cacheSize,
+            className: props.className
         });
         this.eventSources = [this.ol, this.source];
     }

--- a/src/layer/RLayerVectorMBTiles.tsx
+++ b/src/layer/RLayerVectorMBTiles.tsx
@@ -105,7 +105,8 @@ export default class RLayerVectorMBTiles<
         this.addon = import('ol-mbtiles');
         this.ol = new LayerVectorTile({
             style: RStyle.getStyle(this.props.style),
-            renderBuffer: this.props.renderBuffer
+            renderBuffer: this.props.renderBuffer,
+            className: this.props.className
         });
         this.eventSources = [this.ol];
         RFeature.initEventRelay(this.context.map);

--- a/src/layer/RLayerVectorTile.tsx
+++ b/src/layer/RLayerVectorTile.tsx
@@ -113,7 +113,8 @@ export default class RLayerVectorTile<F extends FeatureLike = RenderFeature> ext
         this.ol = new LayerVectorTile({
             style: RStyle.getStyle(this.props.style),
             source: this.source,
-            renderBuffer: this.props.renderBuffer
+            renderBuffer: this.props.renderBuffer,
+            className: this.props.className
         });
         this.eventSources = [this.ol, this.source];
         RFeature.initEventRelay(this.context.map);

--- a/src/layer/RLayerWMTS.tsx
+++ b/src/layer/RLayerWMTS.tsx
@@ -37,7 +37,7 @@ export default class RLayerWMTS extends RLayerRaster<RLayerWMTSProps> {
 
     constructor(props: Readonly<RLayerWMTSProps>, context?: React.Context<RContextType>) {
         super(props, context);
-        this.ol = new LayerTile({source: this.source});
+        this.ol = new LayerTile({source: this.source, className: props.className});
         this.parser = new WMTSCapabilities();
     }
 

--- a/src/layer/ROSM.tsx
+++ b/src/layer/ROSM.tsx
@@ -23,7 +23,7 @@ export default class ROSM extends LayerRaster<ROSMProps> {
     constructor(props: Readonly<ROSMProps>, context?: React.Context<RContextType>) {
         super(props, context);
         this.source = new OSM();
-        this.ol = new LayerTile({source: this.source});
+        this.ol = new LayerTile({source: this.source, className: props.className});
         this.eventSources = [this.ol, this.source];
     }
 

--- a/src/layer/ROSMWebGL.tsx
+++ b/src/layer/ROSMWebGL.tsx
@@ -27,7 +27,8 @@ export default class ROSMWebGL extends RLayerWebGL<ROSMWebGLProps, ImageTile> {
         this.source = new OSM() as unknown as SourceDataTile<ImageTile>;
         this.ol = new LayerTileWebGL({
             source: this.source as unknown as SourceDataTile<DataTile>,
-            cacheSize: props.cacheSize
+            cacheSize: props.cacheSize,
+            className: props.className
         });
         this.eventSources = [this.ol, this.source];
     }


### PR DESCRIPTION
The `className` prop was missing (defined as the first prop here: https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html), so I added it to all layers.